### PR TITLE
adding --keep-going option

### DIFF
--- a/esg_mapfiles.py
+++ b/esg_mapfiles.py
@@ -58,7 +58,7 @@ def _get_args():
                         description="""Build ESG-F mapfiles upon local ESG-F datanode bypassing esgscan_directory\ncommand-line.""",
                         formatter_class = RawTextHelpFormatter,
                         add_help=False,
-                        epilog = "Developped by Levavasseur, G. (CNRS/IPSL)")
+                        epilog = "Developed by Levavasseur, G. (CNRS/IPSL)")
     parser.add_argument('directory',
                         type=str,
                         nargs = '?',


### PR DESCRIPTION
I was finding it inconvenient in some situations that a file in the directory that could not be included (because the regexp was not matched or the file could not be opened) was causing the scan to stop. I have added a --keep-going option to optionally override this.