### PR TITLE
further tweaks

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,9 +9,9 @@ Here is the command-line help:
 .. code-block:: bash
 
    $> esg_mapfiles -h
-   usage: esgmapfiles [-h] -p PROJECT [-c CONFIG] [-o OUTDIR] [-l [LOGDIR]]
-                      [-m MAPFILE] [-d] [-L] [-w] [-C] [-k] [-v] [-V]
-                      directory [directory ...]
+   usage: esg_mapfiles [-h] -p PROJECT [-c CONFIG] [-o OUTDIR] [-l [LOGDIR]]
+                       [-m MAPFILE] [-d] [-L] [-w] [-C] [-v] [-V]
+                       directory [directory ...]
 
    Build ESGF mapfiles upon local ESGF datanode bypassing esgscan_directory
    command-line.

--- a/esgmapfiles/checkvocab.py
+++ b/esgmapfiles/checkvocab.py
@@ -8,6 +8,7 @@
 # Module imports
 import re
 import os
+import sys
 import logging
 import argparse
 from argparse import RawTextHelpFormatter
@@ -265,7 +266,10 @@ def main():
     dsets = get_dsets_from_tree(ctx)
     # Get facets values used by DRS tree
     facet_values_tree = get_facet_values_from_tree(ctx, dsets, facets)
-    compare_values(ctx.project, facets, facet_values_tree, facet_values_config)
+    any_disallowed = compare_values(ctx.project, facets, facet_values_tree, facet_values_config)
+    if any_disallowed:
+        sys.exit(1)
+
 
 # Main entry point for stand-alone call.
 if __name__ == '__main__':

--- a/esgmapfiles/esgmapfiles.py
+++ b/esgmapfiles/esgmapfiles.py
@@ -97,7 +97,14 @@ def get_args(job):
         description="""Build ESGF mapfiles upon local ESGF datanode bypassing esgscan_directory\ncommand-line.""",
         formatter_class=RawTextHelpFormatter,
         add_help=False,
-        epilog="""Developed by Levavasseur, G. (CNRS/IPSL)""")
+        epilog="""
+
+Exit status:
+        0 successful scanning of all files encountered
+        1 no valid data files found and no mapfile produced
+        2 a mapfile was produced but some files were skipped
+
+Developed by Levavasseur, G. (CNRS/IPSL)""")
     parser.add_argument(
         'directory',
         type=str,
@@ -389,11 +396,7 @@ def run(job=None):
      * Instantiates threads pools,
      * Copies mapfile(s) to the output directory,
      * Removes the temporary directory and its contents.
-
-    Exit status:
-        0 successful scanning of all files encountered
-        1 no valid data files found and no mapfile produced
-        2 a mapfile was produced but some files were skipped
+     * Implement exit status values as described in get_args (search for 'epilog')
 
     :param dict job: A job from SYNDA if supplied instead of classical command-line use.
 

--- a/esgmapfiles/esgmapfiles.py
+++ b/esgmapfiles/esgmapfiles.py
@@ -182,8 +182,6 @@ def get_master_ID(attributes, ctx):
     dataset_ID = ctx.cfg.get(ctx.project, 'dataset_ID')
     facets = re.split('\.|#', dataset_ID)
     for facet in facets:
-        if facet == 'project':
-            dataset_ID = dataset_ID.replace(facet, attributes[facet].lower())
         dataset_ID = dataset_ID.replace(facet, attributes[facet])
     return dataset_ID
 


### PR DESCRIPTION
Guillaume,

Sorry about the delay in looking at this.  It looks good, but:

* although the project is free case in the scanning, the output is still enforcing lower case (in the dataset column 1 and in the mapfile filename), so this removes this

* Regarding the "-k" that you removed, in principle it is a bad thing if the "--verbose" option changes the behaviour in ways other than to add extra verbosity.  In fact, the way you that have implemented it, the call to logging.Exception occurs inside the thread, so it does not make the top-level process stop in any case.  This was perhaps not your intention, but I think the effect is good, because then the "always continue" behaviour does not depend on whether --verbose is used.  However, the user might still have some use case for rigorous checking whether all files were scanned properly.  Therefore I have now added an exit value of 2 from the main program where some files were skipped. (Compare: 0 if all files scanned okay, and 1 if no mapfile was produced.)  This gives the user something that they can test for, and is now documented in the usage text.

Regards,
Alan